### PR TITLE
$orの処理を修正 & $andに対応

### DIFF
--- a/lib/filter_array.js
+++ b/lib/filter_array.js
@@ -18,21 +18,22 @@ const hit = (values, conditions) => {
   if (Array.isArray(conditions)) {
     return conditions.some((conditions) => hit(values, conditions))
   }
-  const {$or} = conditions
-  if ($or) {
-    const eachConditions = [].concat($or)
-      .map((or) => {
-        const condition = Object.assign({}, conditions, or)
-        delete condition.$or
-        return condition
-      })
-    return hit(values, eachConditions)
-  }
 
   for (const name of Object.keys(conditions)) {
-    const value = values[name]
-    const condition = conditions[name]
-    const rejected = !hitForValue(value, condition)
+    let rejected = false
+
+    switch (name) {
+      case '$or':
+        rejected = !conditions[name].some(condition => hit(values, condition))
+        break
+      case '$and':
+        rejected = !conditions[name].every(condition => hit(values, condition))
+        break
+      default:
+        rejected = !hitForValue(values[name], conditions[name])
+        break
+    }
+
     if (rejected) {
       return false
     }

--- a/test/filter_array_test.js
+++ b/test/filter_array_test.js
@@ -54,6 +54,21 @@ describe('filter-array', function () {
       filterArray([{v: 100}, {v: 300}], {$or: [{v: {$notBetween: [150, 350]}}]}),
       [{v: 100}]
     )
+
+    deepEqual(
+      filterArray([{v: 100}, {v: 300}, {v: 500}, {v: 700}], {v: { $between: [0, 500] }, $or: [{v: { $ne: 300 }}]}),
+      [{v: 100}, {v: 500}]
+    )
+
+    deepEqual(
+      filterArray([{v: 100}, {v: 300}, {v: 500}, {v: 700}], {v: { $between: [0, 500] }, $or: [{v: { $ne: 300 }}, {v: { $ne: 500 }}]}),
+      [{v: 100}, {v: 300}, {v: 500}]
+    )
+
+    deepEqual(
+      filterArray([{v: 100}, {v: 300}, {v: 500}, {v: 700}], {v: { $between: [0, 500] }, $and: [{v: { $ne: 300 }}, {v: { $ne: 500 }}]}),
+      [{v: 100}]
+    )
   }))
 
   it('Filter by ref', () => co(function * () {

--- a/test/filter_array_test.js
+++ b/test/filter_array_test.js
@@ -69,6 +69,16 @@ describe('filter-array', function () {
       filterArray([{v: 100}, {v: 300}, {v: 500}, {v: 700}], {v: { $between: [0, 500] }, $and: [{v: { $ne: 300 }}, {v: { $ne: 500 }}]}),
       [{v: 100}]
     )
+
+    deepEqual(
+      filterArray([{v: 100, w: 1}, {v: 300, w: 2}, {v: 500, w: 1}, {v: 700, w: 3}], {$and: [{$or: [{v: 100}, {v: 300}]}, {$or: [{w: 2}, {w: 3}]}]}),
+      [{v: 300, w: 2}]
+    )
+
+    deepEqual(
+      filterArray([{v: 100, w: 1}, {v: 300, w: 2}, {v: 500, w: 1}, {v: 700, w: 3}], {$or: [{$or: [{v: 100}, {v: 300}]}, {$or: [{w: 2}, {w: 3}]}]}),
+      [{v: 100, w: 1}, {v: 300, w: 2}, {v: 700, w: 3}]
+    )
   }))
 
   it('Filter by ref', () => co(function * () {


### PR DESCRIPTION
`$or`の処理で、`{a: 1, $or: [ {b: 1}, {c: 1}]}` を `[{a: 1, b: 1}, {a: 1, c: 1}]`と展開する処理の場合、
`{a: 1, $or: [{a: 2}, {a: 3}]}`の場合に、`[{a: 2}, {a: 3}]`となってしまうため、展開せずに`$or`のみでチェックするようにした。

ほとんど同じ処理で、`$and`へも対応できるため追加した。